### PR TITLE
News Z site landing page 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>News Z · Solana-native intelligence</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="page-header">
+    <div class="brand">News Z</div>
+    <nav class="nav">
+      <a href="#how-it-works">Product</a>
+      <a href="#solana">Solana</a>
+      <a href="#watchlist">Watchlist</a>
+      <a href="#news-feed">Feed</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero" id="top">
+      <div class="hero-content">
+        <h1>Solana-based global economic intelligence for retail investors</h1>
+        <p class="tagline">News Z blends AI curation with verifiable on-chain signals anchored to Solana's high-throughput ledger.</p>
+        <p class="subtitle">Subscribe to a calm, Notion-inspired workspace where your market perspective stays organized, auditable, and aligned with the assets you actually follow.</p>
+        <div class="hero-actions">
+          <a class="cta" href="#watchlist">Build your watchlist</a>
+          <span class="hero-note">No wallets required to explore. Solana settlement keeps provenance intact.</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="how-it-works">
+      <h2>How News Z keeps you ahead</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>AI signal notebooks</h3>
+          <p>Digest macro reports, policy releases, and alternative data in clean briefs automatically structured as linked Notion pages.</p>
+        </article>
+        <article class="card">
+          <h3>Solana time-stamping</h3>
+          <p>Each insight is notarized on Solana for transparent lineage, enabling instant verification of who published what and when.</p>
+        </article>
+        <article class="card">
+          <h3>Personal watch views</h3>
+          <p>Organize assets, sectors, and narratives into bespoke dashboards that surface only what matters to you.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="solana">
+      <h2>Why Solana underpins our data integrity</h2>
+      <div class="stack-card">
+        <p>News Z streams AI-generated memos to a Solana program that immutably records event hashes and analyst attestations. Fast finality and low fees mean even granular retail signals are worth anchoring.</p>
+        <ul>
+          <li>Validator health metrics trigger reliability scores directly in your workspace.</li>
+          <li>Cross-program invocations tie DeFi liquidity shifts to market narratives for instant context.</li>
+          <li>Solana Pay webhooks deliver optional tipping to analysts whose annotations you star.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section" id="watchlist">
+      <div class="section-header">
+        <h2>Your Watchlist</h2>
+        <p>Add tickers, chains, or macro themes to customize the feed below.</p>
+      </div>
+      <form id="watchlist-form" class="watchlist-form">
+        <label for="watchlist-input">Add item</label>
+        <div class="input-group">
+          <input id="watchlist-input" type="text" placeholder="e.g. SOL, BTC, Fed policy" autocomplete="off" required>
+          <button type="submit">Add</button>
+        </div>
+      </form>
+      <ul id="watchlist-items" class="watchlist-items" aria-live="polite"></ul>
+    </section>
+
+    <section class="section" id="news-feed">
+      <div class="section-header">
+        <h2>Live intelligence feed</h2>
+        <p>Stories are grouped by the watchlist items you track. Remove an item to adjust your feed.</p>
+      </div>
+      <div id="news-container" class="news-container" aria-live="polite"></div>
+    </section>
+
+    <section class="section" id="features">
+      <h2>Workflow highlights</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Calm briefing rhythm</h3>
+          <p>Digestible summaries roll into shared pages with backlinks, inline comments, and version history familiar to Notion power users.</p>
+        </article>
+        <article class="card">
+          <h3>Community intelligence</h3>
+          <p>Tap into verified on-chain analysts who annotate signals with context, sentiment, and actionable ideas.</p>
+        </article>
+        <article class="card">
+          <h3>Global coverage</h3>
+          <p>Track monetary policy, commodities, digital assets, and emerging markets with localized reporting translated in real time.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>&copy; <span id="year"></span> News Z. Solana-native intelligence for empowered retail investors.</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,145 @@
+const watchlistForm = document.getElementById('watchlist-form');
+const watchlistInput = document.getElementById('watchlist-input');
+const watchlistItems = document.getElementById('watchlist-items');
+const newsContainer = document.getElementById('news-container');
+const yearEl = document.getElementById('year');
+
+const sampleNews = [
+  {
+    title: 'Solana validator uptime improves ahead of upgrade',
+    summary:
+      'Telemetry nodes flag a 9% improvement in epoch uptime while Solana Foundation highlights new client releases shipping quic-based networking.',
+    tags: ['SOL', 'Validator health', 'Infrastructure'],
+    source: 'Solana Chain AI',
+    time: '8 minutes ago'
+  },
+  {
+    title: 'Stablecoin flows rotate toward Solana DeFi',
+    summary:
+      'AI wallet clustering shows $74M in net inflows to Solana AMMs as liquidity providers chase higher fee tiers post-governance vote.',
+    tags: ['DeFi', 'Stablecoins', 'Solana'],
+    source: 'Flowsight AI',
+    time: '22 minutes ago'
+  },
+  {
+    title: 'Federal Reserve signals data-dependent rate path',
+    summary:
+      'FOMC minutes highlight a split between hawks and doves while AI sentiment flags elevated mentions of “soft landing” across macro reports.',
+    tags: ['Fed policy', 'Rates', 'Macro'],
+    source: 'MacroPulse AI',
+    time: '36 minutes ago'
+  },
+  {
+    title: 'Copper futures jump on China stimulus hints',
+    summary:
+      'AI translation of local policy drafts suggests accelerated infrastructure spending, supporting demand-sensitive commodities.',
+    tags: ['Commodities', 'China', 'Stimulus'],
+    source: 'GlobalFluent AI',
+    time: '2 hours ago'
+  }
+];
+
+const activeWatchlist = new Set();
+
+function renderWatchlist() {
+  watchlistItems.innerHTML = '';
+
+  if (activeWatchlist.size === 0) {
+    const emptyState = document.createElement('li');
+    emptyState.className = 'empty';
+    emptyState.textContent = 'No items yet. Add a ticker or theme to start tracking.';
+    watchlistItems.appendChild(emptyState);
+    newsContainer.innerHTML = '';
+    return;
+  }
+
+  activeWatchlist.forEach((item) => {
+    const li = document.createElement('li');
+    li.textContent = item;
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'remove';
+    removeBtn.textContent = '×';
+    removeBtn.addEventListener('click', () => {
+      activeWatchlist.delete(item);
+      renderWatchlist();
+      renderNews();
+    });
+
+    li.appendChild(removeBtn);
+    watchlistItems.appendChild(li);
+  });
+}
+
+function renderNews() {
+  newsContainer.innerHTML = '';
+
+  if (activeWatchlist.size === 0) {
+    const emptyState = document.createElement('div');
+    emptyState.className = 'news-card empty';
+    emptyState.innerHTML = '<p>Add items to your watchlist to see curated intelligence here.</p>';
+    newsContainer.appendChild(emptyState);
+    return;
+  }
+
+  const watchlistArray = Array.from(activeWatchlist);
+
+  const filtered = sampleNews.filter((news) =>
+    watchlistArray.some((item) =>
+      news.tags.some((tag) => tag.toLowerCase().includes(item.toLowerCase())) ||
+      news.title.toLowerCase().includes(item.toLowerCase()) ||
+      news.summary.toLowerCase().includes(item.toLowerCase())
+    )
+  );
+
+  if (filtered.length === 0) {
+    const emptyCard = document.createElement('div');
+    emptyCard.className = 'news-card empty';
+    emptyCard.innerHTML = '<p>No signals yet. Our AI will notify you the moment something relevant hits the chain.</p>';
+    newsContainer.appendChild(emptyCard);
+    return;
+  }
+
+  filtered.forEach((news) => {
+    const card = document.createElement('article');
+    card.className = 'news-card';
+
+    const title = document.createElement('h3');
+    title.textContent = news.title;
+
+    const meta = document.createElement('div');
+    meta.className = 'meta';
+    meta.innerHTML = `<span class="badge">${news.source}</span><span>${news.time}</span>`;
+
+    const summary = document.createElement('p');
+    summary.textContent = news.summary;
+
+    const tags = document.createElement('div');
+    tags.className = 'meta tags';
+    tags.innerHTML = news.tags.map((tag) => `<span class="tag">${tag}</span>`).join('');
+
+    card.appendChild(title);
+    card.appendChild(meta);
+    card.appendChild(summary);
+    card.appendChild(tags);
+
+    newsContainer.appendChild(card);
+  });
+}
+
+watchlistForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const value = watchlistInput.value.trim();
+  if (!value) return;
+
+  activeWatchlist.add(value);
+  watchlistInput.value = '';
+  renderWatchlist();
+  renderNews();
+});
+
+yearEl.textContent = new Date().getFullYear();
+
+renderWatchlist();
+renderNews();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,342 @@
+:root {
+  --bg: #f7f6f3;
+  --surface: #ffffff;
+  --surface-muted: #f1f0ea;
+  --text: #2f3437;
+  --muted: #6c6e72;
+  --accent: #0b6e99;
+  --border: #d3d1cb;
+  --radius: 12px;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  padding-bottom: 3rem;
+}
+
+.page-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem clamp(1.5rem, 4vw, 3.5rem);
+  background: rgba(247, 246, 243, 0.9);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(8px);
+}
+
+.brand {
+  font-weight: 600;
+  font-size: 1.25rem;
+}
+
+.nav {
+  display: flex;
+  gap: 1.25rem;
+  font-size: 0.95rem;
+}
+
+.nav a {
+  color: var(--muted);
+  text-decoration: none;
+  padding-bottom: 0.2rem;
+  border-bottom: 1px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.nav a:hover,
+.nav a:focus {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 clamp(1.5rem, 4vw, 3.5rem) 4rem;
+}
+
+.hero {
+  padding: 4.5rem 0 3rem;
+}
+
+.hero-content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.2rem, 4vw, 3.4rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.tagline {
+  font-size: 1.1rem;
+  color: var(--accent);
+  font-weight: 500;
+}
+
+.subtitle {
+  color: var(--muted);
+  max-width: 640px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.75rem;
+  border-radius: calc(var(--radius) + 6px);
+  background: var(--text);
+  color: var(--surface);
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 24px rgba(47, 52, 55, 0.12);
+}
+
+.cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(47, 52, 55, 0.18);
+}
+
+.hero-note {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.section {
+  margin-bottom: 3.5rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.section-header {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.section-header p {
+  color: var(--muted);
+}
+
+h2 {
+  font-size: 1.9rem;
+  font-weight: 600;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card,
+.stack-card,
+.news-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: 0 6px 18px rgba(17, 17, 17, 0.05);
+}
+
+.card h3,
+.news-card h3 {
+  margin-bottom: 0.5rem;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.card p,
+.stack-card p,
+.news-card p {
+  color: var(--muted);
+}
+
+.stack-card ul {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.65rem;
+  padding-left: 1.25rem;
+  color: var(--muted);
+}
+
+.watchlist-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.watchlist-form label {
+  font-weight: 500;
+}
+
+.input-group {
+  display: flex;
+  gap: 0.75rem;
+}
+
+input[type="text"] {
+  flex: 1;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background-color: var(--surface);
+  color: var(--text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type="text"]:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(11, 110, 153, 0.12);
+}
+
+button {
+  padding: 0.85rem 1.5rem;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  background: var(--surface-muted);
+  color: var(--text);
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+button:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(47, 52, 55, 0.1);
+}
+
+.watchlist-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  list-style: none;
+}
+
+.watchlist-items li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1rem;
+  border-radius: calc(var(--radius) + 8px);
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  font-weight: 500;
+}
+
+.watchlist-items li .remove {
+  padding: 0.2rem 0.6rem;
+  border-radius: calc(var(--radius));
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  box-shadow: none;
+}
+
+.watchlist-items li .remove:hover {
+  color: var(--accent);
+}
+
+.watchlist-items .empty {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: calc(var(--radius) + 8px);
+  background: transparent;
+  border: 1px dashed var(--border);
+  color: var(--muted);
+}
+
+.news-container {
+  display: grid;
+  gap: 1rem;
+}
+
+.news-card .meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: calc(var(--radius));
+  background: var(--surface-muted);
+  color: var(--text);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.tags .tag {
+  display: inline-flex;
+  padding: 0.3rem 0.6rem;
+  border-radius: calc(var(--radius));
+  background: transparent;
+  border: 1px solid var(--border);
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.empty {
+  text-align: center;
+  color: var(--muted);
+}
+
+.news-card.empty {
+  border-style: dashed;
+  background: var(--surface-muted);
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 1.5rem 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 680px) {
+  .nav {
+    display: none;
+  }
+
+  .hero {
+    padding-top: 3.5rem;
+  }
+
+  .input-group {
+    flex-direction: column;
+  }
+
+  button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the News Z landing page with a Notion-inspired light workspace layout and sticky navigation
- emphasize Solana-backed data integrity across new messaging sections and hero copy
- refresh sample intelligence feed data and UI elements to highlight Solana activity

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e85d5b5c2c83328b612dea995e914d